### PR TITLE
Fix pylint issue: use open without explicitly specifying an encoding.

### DIFF
--- a/snippet_uiautomator/uidevice.py
+++ b/snippet_uiautomator/uidevice.py
@@ -364,7 +364,9 @@ class UiDevice:
       content = xml.dom.minidom.parseString(content).toprettyxml(indent='  ')
     if file:
       with open(
-          self.log_path.joinpath(f'window_dump,{timestamp}.xml'), 'w'
+          self.log_path.joinpath(f'window_dump,{timestamp}.xml'),
+          'w',
+          encoding='utf8',
       ) as f:
         print(content, file=f)
     else:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/15)
<!-- Reviewable:end -->
