### PR TITLE
Parse byte string before decoding to string

### DIFF
--- a/snippet_uiautomator/errors.py
+++ b/snippet_uiautomator/errors.py
@@ -32,7 +32,7 @@ ERROR_WHEN_SERVICE_ALREADY_REGISTERED = (
 )
 ERROR_WHEN_SERVICE_NOT_RUNNING = 'Snippet UiAutomator service is not running'
 
-REGEX_UIA_SERVICE_ALREADY_REGISTERED = rb'.*UiAutomationService.*registered'
+REGEX_UIA_SERVICE_ALREADY_REGISTERED = r'.*UiAutomationService.*registered'
 REGEX_TCP_PORT_NOT_FOUND = rb"adb: error: listener 'tcp:(\d+)' not found\n|$"
 
 

--- a/snippet_uiautomator/errors.py
+++ b/snippet_uiautomator/errors.py
@@ -32,7 +32,7 @@ ERROR_WHEN_SERVICE_ALREADY_REGISTERED = (
 )
 ERROR_WHEN_SERVICE_NOT_RUNNING = 'Snippet UiAutomator service is not running'
 
-REGEX_UIA_SERVICE_ALREADY_REGISTERED = r'.*UiAutomationService.*registered'
+REGEX_UIA_SERVICE_ALREADY_REGISTERED = rb'.*UiAutomationService.*registered'
 REGEX_TCP_PORT_NOT_FOUND = rb"adb: error: listener 'tcp:(\d+)' not found\n|$"
 
 

--- a/snippet_uiautomator/utils.py
+++ b/snippet_uiautomator/utils.py
@@ -26,12 +26,9 @@ from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import snippet_client_v2
 from snippet_uiautomator import errors
 
-REGEX_LOGCAT_TIMESTAMP = rb'\d{2}-\d{2}\s{1,2}\d{2}:\d{2}:\d{2}.\d{3}'
+REGEX_LOGCAT_TIMESTAMP = r'\d{2}-\d{2}\s{1,2}\d{2}:\d{2}:\d{2}.\d{3}'
 REGEX_UIA_SERVICE_ALREADY_REGISTERED = (
-    b'('
-    + REGEX_LOGCAT_TIMESTAMP
-    + b')'
-    + errors.REGEX_UIA_SERVICE_ALREADY_REGISTERED
+    rf'({REGEX_LOGCAT_TIMESTAMP}){errors.REGEX_UIA_SERVICE_ALREADY_REGISTERED}'
 )
 
 TimeUnit = Union[float, int, datetime.timedelta]
@@ -48,7 +45,7 @@ def get_latest_logcat_timestamp(ad: android_device.AndroidDevice) -> str:
   """Gets the latest timestamp from logcat."""
   logcat = ad.adb.logcat(['-d'])
   last_line = logcat.splitlines()[-1]
-  return re.findall(REGEX_LOGCAT_TIMESTAMP, last_line)[-1].decode()
+  return re.findall(REGEX_LOGCAT_TIMESTAMP.encode(), last_line)[-1].decode()
 
 
 def get_mobly_ad_log_path(
@@ -85,7 +82,9 @@ def is_uiautomator_service_registered(
       will only check the log after this time point.
   """
   logcat = ad.adb.logcat(['-d', '-s', 'AndroidRuntime:E'])
-  runtime_errors = re.findall(REGEX_UIA_SERVICE_ALREADY_REGISTERED, logcat)
+  runtime_errors = re.findall(
+      REGEX_UIA_SERVICE_ALREADY_REGISTERED.encode(), logcat
+  )
   if not runtime_errors:
     return False
 


### PR DESCRIPTION
Since sometimes characters with different encodings may appear in logcat, causing UnicodeDecodeError, so find the timestampe first and then decode it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/25)
<!-- Reviewable:end -->
