### PR TITLE
Include device debug tag when raising an error

### DIFF
--- a/snippet_uiautomator/errors.py
+++ b/snippet_uiautomator/errors.py
@@ -14,15 +14,17 @@
 
 """Common errors for Snippet UiAutomator."""
 
+from typing import Optional
+
+from mobly.controllers import android_device
+
 ERROR_WHEN_APK_IS_NOT_INSTALLED = (
     '`skip_installing` is True but package {package_name} is not installed'
 )
 ERROR_WHEN_FILE_PATH_MISSING = (
     'Need to provide file path to configuration for installing snippet'
 )
-ERROR_WHEN_INSTANCE_MISSING = (
-    'Missing UiDevice instance {instance} from AndroidDevice {serial}'
-)
+ERROR_WHEN_INSTANCE_MISSING = 'Missing UiDevice instance {instance}'
 ERROR_WHEN_PACKAGE_NAME_MISSING = (
     'Need to provide package name to configuration for launching snippet'
 )
@@ -39,23 +41,29 @@ REGEX_TCP_PORT_NOT_FOUND = rb"adb: error: listener 'tcp:(\d+)' not found\n|$"
 class BaseError(Exception):
   """Base error for Snippet UiAutomator."""
 
-  def __init__(self, serial: str, message: str) -> None:
-    self._serial = serial
+  def __init__(
+      self, message: str, ad: Optional[android_device.AndroidDevice] = None
+  ) -> None:
+    self._ad = ad
     self._message = message
 
   def __str__(self) -> str:
-    return f'[AndroidDevice|{self._serial}] {self._message}'
+    return (
+        self._message
+        if self._ad is None
+        else f'[AndroidDevice|{self._ad.debug_tag}] {self._message}'
+    )
 
 
-class ApiError(Exception):
+class ApiError(BaseError):
   """Raised when an inexistent API is called or API is used incorrectly."""
 
 
-class ConfigurationError(Exception):
+class ConfigurationError(BaseError):
   """Raised when passed incorrect configuration to Snippet UiAutomator."""
 
 
-class UiAutomatorError(Exception):
+class UiAutomatorError(BaseError):
   """Raised when fail to operate UiAutomator."""
 
 

--- a/snippet_uiautomator/uiautomator.py
+++ b/snippet_uiautomator/uiautomator.py
@@ -130,7 +130,8 @@ class UiAutomatorService(base_service.BaseService):
         raise errors.ConfigurationError(
             errors.ERROR_WHEN_APK_IS_NOT_INSTALLED.format(
                 package_name=self._configs.snippet.package_name
-            )
+            ),
+            self._device,
         )
     else:
       if self._is_apk_installed:
@@ -148,8 +149,9 @@ class UiAutomatorService(base_service.BaseService):
       return
 
     if self._configs.snippet.package_name is None:
-      raise errors.ConfigurationError(errors.ERROR_WHEN_PACKAGE_NAME_MISSING)
-
+      raise errors.ConfigurationError(
+          errors.ERROR_WHEN_PACKAGE_NAME_MISSING, self._device
+      )
     start_time = utils.get_latest_logcat_timestamp(self._device)
     try:
       self._device.load_snippet(
@@ -158,7 +160,7 @@ class UiAutomatorService(base_service.BaseService):
     except snippet_errors.ServerStartProtocolError as e:
       if utils.is_uiautomator_service_registered(self._device, start_time):
         raise errors.UiAutomationServiceAlreadyRegisteredError(
-            self._device.serial, errors.ERROR_WHEN_SERVICE_ALREADY_REGISTERED
+            errors.ERROR_WHEN_SERVICE_ALREADY_REGISTERED, self._device
         ) from e
       raise
 
@@ -176,16 +178,18 @@ class UiAutomatorService(base_service.BaseService):
   def ui_device(self) -> UiDevice:
     """Gets the UiDevice object."""
     if not self.is_alive:
-      raise errors.ConfigurationError(errors.ERROR_WHEN_SERVICE_NOT_RUNNING)
+      raise errors.ConfigurationError(
+          errors.ERROR_WHEN_SERVICE_NOT_RUNNING, self._device
+      )
     service = getattr(
         self._device, self._configs.snippet.ui_public_service_name, None
     )
     if service is None:
       raise errors.ConfigurationError(
           errors.ERROR_WHEN_INSTANCE_MISSING.format(
-              instance=self._configs.snippet.ui_public_service_name,
-              serial=self._device.serial,
-          )
+              instance=self._configs.snippet.ui_public_service_name
+          ),
+          self._device,
       )
     return service
 

--- a/snippet_uiautomator/uidevice.py
+++ b/snippet_uiautomator/uidevice.py
@@ -50,6 +50,7 @@ class _Press:
 
   def __init__(self, ui: snippet_client_v2.SnippetClientV2) -> None:
     self._ui = ui
+    self._device = self._ui._device  # pylint: disable=protected-access
 
   def __call__(
       self, keycode: Union[int, str, Sequence[int]], meta: Optional[int] = None
@@ -87,7 +88,10 @@ class _Press:
       return self._ui.pressKeyCode(0x000000A4)
     elif keycode == 'volume_up':
       return self._ui.pressKeyCode(0x00000018)
-    raise AttributeError(f"'_Press' object has no attribute {repr(keycode)}")
+    raise AttributeError(
+        f"[AndroidDevice|{self._device.debug_tag}] '_Press' object has no"
+        f' attribute {repr(keycode)}'
+    )
 
 
 class _Screen:
@@ -160,8 +164,8 @@ class UiDevice:
       raise_error: bool = False,
   ) -> None:
     self._ui = ui
-    self._device = self._ui._device  # pylint: disable=protected-access
     self._compressed = False
+    self._device = self._ui._device  # pylint: disable=protected-access
     self._serial = self._device.serial
     self._raise_error = raise_error
     self.log_path = pathlib.Path(self._device.log_path)
@@ -232,7 +236,7 @@ class UiDevice:
       self._ui.setOrientationRight()
     else:
       raise errors.UiAutomatorError(
-          f'Cannot set orientation to {new_orientation}.'
+          f'Cannot set orientation to {new_orientation}.', self._device
       )
 
   @property

--- a/snippet_uiautomator/uiwatcher.py
+++ b/snippet_uiautomator/uiwatcher.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from typing import Optional
 
 from mobly.controllers.android_device_lib import snippet_client_v2
-
 from snippet_uiautomator import byselector
 from snippet_uiautomator import constants
 from snippet_uiautomator import errors
@@ -78,6 +77,7 @@ class UiWatcher:
   ) -> None:
     self._ui = ui
     self._condition = byselector.BySelector()
+    self._device = self._ui._device  # pylint: disable=protected-access
     self.name = name
 
   @property
@@ -107,7 +107,8 @@ class UiWatcher:
     """
     if not args:
       raise errors.ApiError(
-          'At least one key code required when UiWatcher is triggered.'
+          'At least one key code required when UiWatcher is triggered.',
+          self._device,
       )
     self._ui.registerWatcherForKeycodes(
         self.name, self._condition.to_dict(), list(args)


### PR DESCRIPTION
In multi-device testing, the original design didn't point out which device raise an error which will need users to look in the `test_log.DEBUG` file to find out device. This improvement makes it easy for users to identify the device that raised an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/40)
<!-- Reviewable:end -->
