### PR TITLE
remove optimization on skipping install

### DIFF
--- a/snippet_uiautomator/uiautomator.py
+++ b/snippet_uiautomator/uiautomator.py
@@ -209,7 +209,6 @@ class UiAutomatorService(base_service.BaseService):
       self._install_apk()
       self._load_snippet()
       self._initial_uidevice()
-      self._configs.skip_installing = True
 
   def stop(self) -> None:
     if not self.is_alive:


### PR DESCRIPTION
optimization on skipping install prevents a stop, power cycle, start of uiautomator snippets from working as the stop removes the package, since this optimization of preventing reinstall is unlikely to be triggered anyways just remove it to fix the bug

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/73)
<!-- Reviewable:end -->
