### PR TITLE
Provide accurate command to fetch device information

### DIFF
--- a/snippet_uiautomator/uiautomator.py
+++ b/snippet_uiautomator/uiautomator.py
@@ -116,7 +116,9 @@ class UiAutomatorService(base_service.BaseService):
   @property
   def _is_apk_installed(self) -> bool:
     """Checks if the snippet apk is already installed."""
-    all_packages = self._device.adb.shell(['pm', 'list', 'package'])
+    all_packages = self._device.adb.shell(
+        ['pm', 'list', 'packages', self._configs.snippet.package_name]
+    )
     return bool(
         mobly_utils.grep(
             f'^package:{self._configs.snippet.package_name}$', all_packages

--- a/snippet_uiautomator/utils.py
+++ b/snippet_uiautomator/utils.py
@@ -50,7 +50,7 @@ def covert_to_millisecond(timeout: TimeUnit, ignore_error: bool = False) -> int:
 
 def get_latest_logcat_timestamp(ad: android_device.AndroidDevice) -> str:
   """Gets the latest timestamp from logcat."""
-  logcat = ad.adb.logcat(['-d'])
+  logcat = ad.adb.logcat(['-b', 'main', '-t', '1'])
   last_line = logcat.splitlines()[-1]
   return re.findall(REGEX_LOGCAT_TIMESTAMP.encode(), last_line)[-1].decode()
 


### PR DESCRIPTION
A long adb command output usually results in large log files (at DEBUG verbosity) and slows down test and upload process. This CL contains 2 improvements:

- Specify the package name in pm list packages to suppress all packages being printed.
- Prints only the last line of the main logcat buffer to prevent whole logcat being recorded to log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/76)
<!-- Reviewable:end -->
