### PR TITLE
Add accessor for underlying selector

### DIFF
--- a/snippet_uiautomator/uiobject2.py
+++ b/snippet_uiautomator/uiobject2.py
@@ -831,3 +831,8 @@ class UiObject2:
     """The point in the center of this object's visible bounds."""
     point = self._ui.getVisibleCenter(self._selector.to_dict())
     return constants.Point(**point)
+
+  @property
+  def selector(self) -> byselector.BySelector:
+    """The selector used to find this object."""
+    return self._selector


### PR DESCRIPTION
The accessor can be useful for logging purposes when the object is not found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/snippet-uiautomator/77)
<!-- Reviewable:end -->
