### PR TITLE
Fix side effect on saved query objects

### DIFF
--- a/snippet_uiautomator/uiobject2.py
+++ b/snippet_uiautomator/uiobject2.py
@@ -19,6 +19,7 @@ https://developer.android.com/reference/androidx/test/uiautomator/UiObject2
 
 from __future__ import annotations
 
+import deepcopy
 from typing import Literal, Mapping, Optional, Sequence, Union
 import warnings
 
@@ -645,7 +646,7 @@ class UiObject2:
 
   def _create_instance(self, tag: str, **kwargs) -> UiObject2:
     """Creates a new instance of this object with the given tag."""
-    selector = self._selector.copy()
+    selector = copy.deepcopy(self._selector)
     selector.append(tag, **kwargs)
     return UiObject2(self._ui, selector, self._raise_error)
 


### PR DESCRIPTION
Before this fix, in the following code example, the second line will modify the `saved_query` object. 

```
saved_query = self.dut.ui(text='AAA').ancestor(res='BBB')
saved_query.child(res='ZZZZZZZZZZZZZZZZZZZ').click()
saved_query.child(text='CCC').wait.exists(3)
```